### PR TITLE
Update createStore Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM version](http://img.shields.io/npm/v/redux-mori.svg?style=flat-square)](https://www.npmjs.org/package/redux-mori)
 
-`redux-mori` is a drop-in replacement for Redux's [`combineReducers`](http://redux.js.org/docs/api/combineReducers.html) that works with [`mori.js`](http://swannodette.github.io/mori) immutable data structures.
+`redux-mori` is a drop-in replacement for Redux's [`combineReducers`](http://redux.js.org/docs/api/combineReducers.html) and [`createStore`](http://redux.js.org/docs/api/createStore.html) that works with [`mori.js`](http://swannodette.github.io/mori) immutable data structures.
 
 Any `preloadedState` for Redux's [`createStore`](https://github.com/reactjs/redux/blob/master/docs/api/createStore.md) should be a `mori` [`hashMap`](http://swannodette.github.io/mori/#hashMap).
 
@@ -10,14 +10,20 @@ Any `preloadedState` for Redux's [`createStore`](https://github.com/reactjs/redu
 
 If you create a store with `preloadedState`, make sure it is an instance of [`hashMap`]((http://swannodette.github.io/mori/#hashMap)):
 
+#### Create Store / Combine Reducers:
 ```js
 import { toClj } from 'mori';
-import { combineReducers } from 'redux-mori';
-import { createStore } from 'redux';
+import { combineReducers, createStore } from 'redux-mori';
 import fooReducer from './fooReducer';
 import bazReducer from './bazReducer';
 
 const preloadedState = toClj({foo: 'bar', baz: 'quux'});
 const rootReducer = combineReducers({fooReducer, bazReducer});
 const store = createStore(rootReducer, preloadedState);
+```
+
+#### Action:
+```js
+const ACTION_REQUEST = 'ACTION_REQUEST'
+const actionRequest = () => hashMap('type', ACTION_REQUEST)
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "redux-mori",
   "version": "0.0.3",
-  "description": "Drop-in replacement for Redux combineReducers that works with mori.js immutable data structures",
+  "description": "Drop-in replacement for Redux combineReducers and createStore that works with mori.js immutable data structures",
   "main": "./dist/index.js",
   "files": [
     "dist"


### PR DESCRIPTION
* Update the `package.json` with relevant description.
* Adds examples of using createStore and action now using `hashMap`.